### PR TITLE
Bug fixes

### DIFF
--- a/Debugger/IDE/IDEView.xaml.cs
+++ b/Debugger/IDE/IDEView.xaml.cs
@@ -263,23 +263,18 @@ namespace Debugger.IDE {
         private void errorDoubleClick(object sender, MouseEventArgs args) {
             DataGridRow row = sender as DataGridRow;
             PluginLib.CompileError result = row.DataContext as PluginLib.CompileError;
-            foreach (string str in IDEProject.inst().GetIncludeDirs())
+
+            if (System.IO.File.Exists(result.File))
             {
-                string path = System.IO.Path.Combine(IDEProject.inst().ProjectDir, str);
-                path = System.IO.Path.Combine(path, result.File);
-                if (System.IO.File.Exists(path))
+                IDEEditor editor = ideTabs.OpenFile(new FileLeafItem
                 {
-                    IDEEditor editor = ideTabs.OpenFile(new FileLeafItem
-                    {
-                        Path = path,
-                        Name = System.IO.Path.GetFileName(path)
-                    });
-                    if (result.Line != -1)
-                    {
-                        editor.Editor.TextArea.Caret.Line = result.Line;
-                        editor.Editor.ScrollToLine(result.Line);
-                    }
-                    return;
+                    Path = result.File,
+                    Name = System.IO.Path.GetFileName(result.File)
+                });
+                if (editor != null && result.Line != -1)
+                {
+                    editor.Editor.TextArea.Caret.Line = result.Line;
+                    editor.Editor.ScrollToLine(result.Line);
                 }
             }
         }
@@ -355,6 +350,7 @@ namespace Debugger.IDE {
             pi.StartInfo.FileName = IDEProject.inst().Settings.RunExe;
             pi.StartInfo.Arguments = IDEProject.inst().Settings.CompilerPath.ToSpaceQuoted() + " " + IDEProject.inst().Settings.RunParams;
             pi.EnableRaisingEvents = true;
+            pi.StartInfo.WorkingDirectory = IDEProject.inst().Settings.ProjectPath;
             pi.StartInfo.UseShellExecute = false;
             pi.StartInfo.CreateNoWindow = false;
             pi.StartInfo.RedirectStandardOutput = false;
@@ -372,6 +368,7 @@ namespace Debugger.IDE {
             pi.StartInfo.FileName = IDEProject.inst().Settings.DebugExe;
             pi.StartInfo.Arguments = IDEProject.inst().Settings.CompilerPath.ToSpaceQuoted() + " " + IDEProject.inst().Settings.DebugParams;
             pi.EnableRaisingEvents = true;
+            pi.StartInfo.WorkingDirectory = IDEProject.inst().Settings.ProjectPath;
             pi.StartInfo.UseShellExecute = false;
             pi.StartInfo.CreateNoWindow = false;
             pi.StartInfo.RedirectStandardOutput = false;

--- a/UrhoCompilerPlugin/UrhoCompiler.cs
+++ b/UrhoCompilerPlugin/UrhoCompiler.cs
@@ -100,11 +100,11 @@ namespace UrhoCompilerPlugin
             }
             if (isError || isWarning)
             {
-                string[] words = str.Split(' '); //split on spaces
-                int colonIndex = words[0].LastIndexOf(':');
-                if (colonIndex == -1)
+                int sPos = str.IndexOf(": ");
+                int colonIndex = str.LastIndexOf(':');
+                if (colonIndex == -1 || colonIndex == sPos)
                     return false; //don't count this as an error
-                string fileName = words[0].Substring(0, colonIndex);
+                string fileName = str.Substring(sPos+1, colonIndex);
 
                 string part = "";
                 int line = -1;
@@ -124,7 +124,7 @@ namespace UrhoCompilerPlugin
                         break;
                     part += str[colonIndex];
                 }
-                string msg = String.Join(" ", words, 1, words.Length - 1); // str.Substring(colonIndex);
+                string msg = str.Substring(colonIndex+1);
                 PluginLib.CompileError error = new PluginLib.CompileError
                 {
                     File = fileName,

--- a/UrhoCompilerPlugin/UrhoCompiler.cs
+++ b/UrhoCompilerPlugin/UrhoCompiler.cs
@@ -101,8 +101,10 @@ namespace UrhoCompilerPlugin
             if (isError || isWarning)
             {
                 int sPos = str.IndexOf(": ");
-                int colonIndex = str.LastIndexOf(':');
-                if (colonIndex == -1 || colonIndex == sPos)
+                int driveIndex = str.IndexOf(':', sPos + 1);
+                int colonIndex = str.IndexOf(':', driveIndex + 1);
+                
+                if (colonIndex == -1)
                     return false; //don't count this as an error
                 string fileName = str.Substring(sPos+1, colonIndex);
 


### PR DESCRIPTION
Hi,

I spotted what I think are some bugs, although these fixes probably need more testing etc.

---

    - Set the working directory of process when playing.

Fix for working directory mentioned here: https://github.com/JSandusky/UrhoAngelscriptIDE/issues/4

---

    - Handle output of multi-compile asynchronously

I made the multi-compile more consistent with single compile (errors that were detected in single compile weren't being detected in multi-compile for me).

---

    - Changed process line so that it doesn't trip on paths with spaces.

When a path had a space, the error message wasn't splitting correctly so I've changed the way that is handled.

---

    - Changed double click error logic to handle full path

I suspect a change I made in ProcessLine caused this to be required.